### PR TITLE
Break line at the end of the annotations

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -199,8 +199,10 @@ module AnnotateModels
         info << "#--\n"
         info << "# #{END_MARK}\n"
         info << "#++\n"
+        info << "\n"
       else
         info << "#\n"
+        info << "\n"
       end
     end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -262,6 +262,7 @@ describe AnnotateModels do
                 #  id   :integer          not null
                 #  name :string(50)       not null
                 #
+
               EOS
             end
 
@@ -287,6 +288,7 @@ describe AnnotateModels do
                 #  id   :integer          not null
                 #  name :enum             not null, (enum1, enum2)
                 #
+
               EOS
             end
 
@@ -320,6 +322,7 @@ describe AnnotateModels do
                 #  float   :float            unsigned, not null
                 #  decimal :decimal(10, 2)   unsigned, not null
                 #
+
               EOS
             end
 
@@ -354,6 +357,7 @@ describe AnnotateModels do
                   #  name  :string(50)       not null
                   #  notes :text(55)         not null
                   #
+
                 EOS
               end
 
@@ -381,6 +385,7 @@ describe AnnotateModels do
                   #  size :integer          default(20), not null
                   #  flag :boolean          default(FALSE), not null
                   #
+
                 EOS
               end
 
@@ -424,6 +429,7 @@ describe AnnotateModels do
                   #  author_name :string(50)       not null
                   #  title       :string(50)       not null
                   #
+
                 EOS
               end
 
@@ -456,6 +462,7 @@ describe AnnotateModels do
                 #  b_id :integer          not null, primary key
                 #  name :string(50)       not null
                 #
+
               EOS
             end
 
@@ -514,6 +521,7 @@ describe AnnotateModels do
                       #  index_rails_02e851e3b7  (id)
                       #  index_rails_02e851e3b8  (foreign_thing_id)
                       #
+
                     EOS
                   end
 
@@ -557,6 +565,7 @@ describe AnnotateModels do
                       #  index_rails_02e851e3b7  (id)
                       #  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
                       #
+
                     EOS
                   end
 
@@ -600,6 +609,7 @@ describe AnnotateModels do
                       #  index_rails_02e851e3b7  (id)
                       #  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
                       #
+
                     EOS
                   end
 
@@ -643,6 +653,7 @@ describe AnnotateModels do
                       #  index_rails_02e851e3b7  (id)
                       #  index_rails_02e851e3b8  (firstname,surname) USING hash
                       #
+
                     EOS
                   end
 
@@ -672,6 +683,7 @@ describe AnnotateModels do
                       #  id               :integer          not null, primary key
                       #  foreign_thing_id :integer          not null
                       #
+
                     EOS
                   end
 
@@ -712,6 +724,7 @@ describe AnnotateModels do
                       #  id               :integer          not null, primary key
                       #  foreign_thing_id :integer          not null
                       #
+
                     EOS
                   end
 
@@ -744,6 +757,7 @@ describe AnnotateModels do
                       #  id   :integer          not null, primary key, indexed
                       #  name :string           not null
                       #
+
                     EOS
                   end
 
@@ -791,6 +805,7 @@ describe AnnotateModels do
                       #  fk_rails_...    (foreign_thing_id => foreign_things.id)
                       #  fk_rails_...    (third_thing_id => third_things.id)
                       #
+
                     EOS
                   end
 
@@ -824,6 +839,7 @@ describe AnnotateModels do
                       #
                       #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
                       #
+
                     EOS
                   end
 
@@ -853,6 +869,7 @@ describe AnnotateModels do
                     #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
                     #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
                     #
+
                   EOS
                 end
 
@@ -888,6 +905,7 @@ describe AnnotateModels do
                     #  name   :string(50)       not null
                     #  notes  :text(55)         not null
                     #
+
                   EOS
                 end
 
@@ -912,6 +930,7 @@ describe AnnotateModels do
                     #  name   :string(50)       not null
                     #  notes  :text(55)         not null
                     #
+
                   EOS
                 end
 
@@ -936,6 +955,7 @@ describe AnnotateModels do
                     #  name   :string           not null
                     #  notes  :text             not null
                     #
+
                   EOS
                 end
 
@@ -969,6 +989,7 @@ describe AnnotateModels do
                     #  settings   :jsonb            not null
                     #  parameters :hstore           not null
                     #
+
                   EOS
                 end
 
@@ -992,6 +1013,7 @@ describe AnnotateModels do
                     #  settings   :jsonb            default({}), not null
                     #  parameters :hstore           default({}), not null
                     #
+
                   EOS
                 end
 
@@ -1015,6 +1037,7 @@ describe AnnotateModels do
                     #  settings   :jsonb            default({}), not null
                     #  parameters :hstore           default({}), not null
                     #
+
                   EOS
                 end
 
@@ -1048,6 +1071,7 @@ describe AnnotateModels do
                     #  name   :string(50)       not null
                     #  notes  :text(55)         not null
                     #
+
                   EOS
                 end
 
@@ -1086,6 +1110,7 @@ describe AnnotateModels do
                       #  notes(Notes)   :text(55)         not null
                       #  no_comment     :text(20)         not null
                       #
+
                     EOS
                   end
 
@@ -1125,6 +1150,7 @@ describe AnnotateModels do
                       #  no_comment                         :text(20)         not null
                       #  location                           :geometry_collect not null
                       #
+
                     EOS
                   end
 
@@ -1152,6 +1178,7 @@ describe AnnotateModels do
                       #  notes(Notes.\\nMay include things like notes.):text(55)         not null
                       #  no_comment                                   :text(20)         not null
                       #
+
                     EOS
                   end
 
@@ -1185,6 +1212,7 @@ describe AnnotateModels do
                       #  geometry :geometry         not null, geometry, 4326
                       #  location :geography        not null, point, 0
                       #
+
                     EOS
                   end
 
@@ -1232,6 +1260,7 @@ describe AnnotateModels do
                   #--
                   # == Schema Information End
                   #++
+
                 EOS
               end
 
@@ -1256,6 +1285,7 @@ describe AnnotateModels do
                   # @!attribute name
                   #   @return [String]
                   #
+
                 EOS
               end
 
@@ -1283,6 +1313,7 @@ describe AnnotateModels do
                     # **`id`**    | `integer`          | `not null, primary key`
                     # **`name`**  | `string(50)`       | `not null`
                     #
+
                   EOS
                 end
 
@@ -1324,6 +1355,7 @@ describe AnnotateModels do
                       # * `index_rails_02e851e3b8`:
                       #     * **`foreign_thing_id`**
                       #
+
                     EOS
                   end
 
@@ -1362,6 +1394,7 @@ describe AnnotateModels do
                       # * `index_rails_02e851e3b8` (_unique_):
                       #     * **`foreign_thing_id`**
                       #
+
                     EOS
                   end
 
@@ -1400,6 +1433,7 @@ describe AnnotateModels do
                       # * `index_rails_02e851e3b8`:
                       #     * **`foreign_thing_id DESC`**
                       #
+
                     EOS
                   end
 
@@ -1439,6 +1473,7 @@ describe AnnotateModels do
                       # * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
                       #     * **`foreign_thing_id`**
                       #
+
                     EOS
                   end
 
@@ -1477,6 +1512,7 @@ describe AnnotateModels do
                       # * `index_rails_02e851e3b8` (_using_ hash):
                       #     * **`foreign_thing_id`**
                       #
+
                     EOS
                   end
 
@@ -1528,6 +1564,7 @@ describe AnnotateModels do
                       # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
                       #     * **`foreign_thing_id => foreign_things.id`**
                       #
+
                     EOS
                   end
 
@@ -1562,6 +1599,7 @@ describe AnnotateModels do
                     #--
                     # == Schema Information End
                     #++
+
                   EOS
                 end
 
@@ -1597,6 +1635,7 @@ describe AnnotateModels do
                     # **`id(ID)`**      | `integer`          | `not null, primary key`
                     # **`name(Name)`**  | `string(50)`       | `not null`
                     #
+
                   EOS
                 end
 
@@ -1626,6 +1665,7 @@ describe AnnotateModels do
                     # **`id(ＩＤ)`**        | `integer`          | `not null, primary key`
                     # **`name(ＮＡＭＥ)`**  | `string(50)`       | `not null`
                     #
+
                   EOS
                 end
 
@@ -2597,7 +2637,7 @@ describe AnnotateModels do
                              ])
           @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_foreign_keys: true)
           annotate_one_file
-          expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+          expect(File.read(@model_file_name)).to eq("#{@schema_info}\n#{@file_content}")
         end
       end
     end
@@ -2611,12 +2651,12 @@ describe AnnotateModels do
 
       it 'should retain current position' do
         annotate_one_file
-        expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        expect(File.read(@model_file_name)).to eq("#{@schema_info}\n#{@file_content}")
       end
 
       it 'should retain current position even when :position is changed to :after' do
         annotate_one_file position: :after
-        expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        expect(File.read(@model_file_name)).to eq("#{@schema_info}\n#{@file_content}")
       end
 
       it 'should change position to :after when force: true' do
@@ -2634,12 +2674,12 @@ describe AnnotateModels do
 
       it 'should retain current position' do
         annotate_one_file
-        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}")
+        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}\n")
       end
 
       it 'should retain current position even when :position is changed to :before' do
         annotate_one_file position: :before
-        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}")
+        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}\n")
       end
 
       it 'should change position to :before when force: true' do


### PR DESCRIPTION
## Description
This adds an empty line at the end of the annotations, this will let us have comments below the annotations without being deleted